### PR TITLE
fix: Update example configuration file

### DIFF
--- a/canary-ng.yaml.example
+++ b/canary-ng.yaml.example
@@ -45,8 +45,10 @@ jobs:
     interval: 4
     query_type: read
     type: valkey
-    dsn: rediss://canary-ng-valkey:6380/0
+    host: canary-ng-valkey
     password: ***
+    port: 6380
+    tls: true
+    skip_verify: true
     key: canary_ng
     create: true
-    skip_verify: true


### PR DESCRIPTION
The Valkey library doesn't support the `skip_verify` query param in the current version. And the DSN overrides all the pre-existing settings. Updating the example file to use each configuration setting instead of a DSN, to make easier to setup a Valkey test instance using Docker.