### PR TITLE
fix(clickhouse): Create distributed table

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:secp384r1 -days 3650 -no
 * `dsn` (string): connection string (ex: `clickhouse://***:***@127.0.0.1:9440/canary_clickhouse?secure=true&skip_verify=true`)
 * `hosts` ([]string): list of hosts
 * `port` (int): connect to this port
+* `cluster` (string): name of the cluster in a replicated setup
 * `username` (string): user name used for authentication
 * `password` (string): password used for authentication
 * `secure` (bool): use TLS for the connection

--- a/src/internal/config.go
+++ b/src/internal/config.go
@@ -55,7 +55,7 @@ type JobConfig struct {
 	AuthMechanism        string            `yaml:"auth_mechanism"`
 	Collection           string            `yaml:"collection"`
 	Table                string            `yaml:"table"`
-	Replicated           bool              `yaml:"replicated"`
+	Cluster              string            `yaml:"cluster"`
 	Key                  string            `yaml:"key"`
 	Create               bool              `yaml:"create"`
 	Secure               bool              `yaml:"secure"`

--- a/src/internal/job.go
+++ b/src/internal/job.go
@@ -150,7 +150,7 @@ func NewJob(config JobConfig, metrics *Metrics, queryLabels QueryLabelsConfig, j
 			Database:   config.Database,
 			Table:      config.Table,
 			Create:     config.Create,
-			Replicated: config.Replicated,
+			Cluster:    config.Cluster,
 			Secure:     config.Secure,
 			SkipVerify: config.SkipVerify,
 			Logger:     logger,


### PR DESCRIPTION
Add `cluster` argument to create replicated and distributed tables on Clickhouse.