### PR TITLE
feat: Periodic host discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,19 @@ openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:secp384r1 -days 3650 -no
 
 Canary NG is able to discover a list of hosts instead of defining `host` or `hosts` in each job configuration.
 
+Discovery runs periodically: hosts that appear are added and hosts that
+disappear are removed without restarting the application. Use `interval` to
+control how often discovery runs (defaults to 60 seconds). When discovery fails
+or returns no host, the currently running jobs are kept so a transient outage
+does not interrupt monitoring.
+
 Example:
 
 ```yaml
 jobs:
   host_discovery:
     type: consul
+    interval: 60
     token: ***
     node_meta:
       dbms_type: postgresql

--- a/src/cmd/canary-ng/main.go
+++ b/src/cmd/canary-ng/main.go
@@ -95,13 +95,19 @@ func main() {
 	metrics := internal.NewMetrics(reg, config)
 
 	for _, jobConfig := range config.Jobs {
+		if jobConfig.HostsDiscovery.Type != "" {
+			dm := internal.NewDiscoveryManager(jobConfig, metrics, config.QueryLabels, config.JobLabelName)
+			go dm.Run()
+			continue
+		}
+
 		jobs, err := internal.NewJobs(jobConfig, metrics, config.QueryLabels, config.JobLabelName)
 		if err != nil {
 			slog.Error("could not create job", slog.Any("job", jobConfig.Name), slog.Any("error", err))
 			continue
 		}
 		for _, j := range jobs {
-			go j.Run()
+			go j.Run(nil)
 		}
 	}
 

--- a/src/driver/mongodb_test.go
+++ b/src/driver/mongodb_test.go
@@ -1,7 +1,6 @@
 package driver
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -20,7 +19,7 @@ func TestMongodbURI(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(fmt.Sprintf(tc.name), func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			m, err := NewMongodb(tc.input)
 			if err != nil {
 				t.Errorf("could not create mongodb: %v", err)
@@ -50,7 +49,7 @@ func TestMongodbTimeout(t *testing.T) {
 		{"with timeout", MongodbOpts{Timeout: 3, DSN: "mongodb://127.0.0.1:27017/canary", Database: "canary", Collection: "canary"}, 3}}
 
 	for _, tc := range tests {
-		t.Run(fmt.Sprintf(tc.name), func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			m, err := NewMongodb(tc.input)
 			if err != nil {
 				t.Errorf("could not create mongodb: %v", err)

--- a/src/driver/postgresql_test.go
+++ b/src/driver/postgresql_test.go
@@ -1,7 +1,6 @@
 package driver
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -24,7 +23,7 @@ func TestPostgresqlDSN(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(fmt.Sprintf(tc.name), func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			m, err := NewPostgresql(tc.input)
 			if err != nil {
 				t.Errorf("could not create postgresql: %v", err)

--- a/src/internal/config.go
+++ b/src/internal/config.go
@@ -70,6 +70,7 @@ type JobConfig struct {
 
 type DiscoveryConfig struct {
 	Type        string            `yaml:"type"`
+	Interval    int               `yaml:"interval"`
 	Addresses   []string          `yaml:"addresses"`
 	Datacenter  string            `yaml:"datacenter"`
 	Scheme      string            `yaml:"scheme"`

--- a/src/internal/discovery_manager.go
+++ b/src/internal/discovery_manager.go
@@ -1,0 +1,90 @@
+package internal
+
+import (
+	"log/slog"
+	"time"
+)
+
+// DiscoveryManager keeps the running jobs of a discovery-based job configuration
+// in sync with the hosts currently returned by discovery. It re-discovers on an
+// interval so hosts appearing or disappearing are picked up without restarting
+// the application.
+type DiscoveryManager struct {
+	config       JobConfig
+	metrics      *Metrics
+	queryLabels  QueryLabelsConfig
+	jobLabelName string
+	interval     time.Duration
+	logger       *slog.Logger
+	running      map[string]chan struct{}
+	discover     func() ([]string, error)
+}
+
+func NewDiscoveryManager(config JobConfig, metrics *Metrics, queryLabels QueryLabelsConfig, jobLabelName string) *DiscoveryManager {
+	interval := config.HostsDiscovery.Interval
+	if interval == 0 {
+		interval = DISCOVERY_INTERVAL
+	}
+
+	return &DiscoveryManager{
+		config:       config,
+		metrics:      metrics,
+		queryLabels:  queryLabels,
+		jobLabelName: jobLabelName,
+		interval:     time.Duration(interval) * time.Second,
+		logger:       slog.With("job", config.Name),
+		running:      map[string]chan struct{}{},
+		discover:     func() ([]string, error) { return DiscoverHosts(config.HostsDiscovery) },
+	}
+}
+
+func (s *DiscoveryManager) Run() {
+	s.logger.Info("discovery manager started", slog.Duration("interval", s.interval))
+	s.reconcile()
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		s.reconcile()
+	}
+}
+
+// reconcile discovers the current hosts and aligns the running jobs with them.
+// On a discovery failure the existing jobs are left running so a transient
+// outage does not interrupt monitoring.
+func (s *DiscoveryManager) reconcile() {
+	hosts, err := s.discover()
+	if err != nil {
+		s.logger.Warn("could not discover hosts", slog.Any("error", err))
+		return
+	}
+	if len(hosts) == 0 {
+		s.logger.Warn("0 host found by discovery")
+		return
+	}
+
+	desired, err := BuildJobs(s.config, hosts, s.metrics, s.queryLabels, s.jobLabelName)
+	if err != nil {
+		s.logger.Warn("could not build jobs", slog.Any("error", err))
+		return
+	}
+
+	for key, stop := range s.running {
+		if _, ok := desired[key]; !ok {
+			s.logger.Info("stopping job for vanished host", slog.String("host", key))
+			close(stop)
+			delete(s.running, key)
+		}
+	}
+
+	for key, job := range desired {
+		if _, ok := s.running[key]; ok {
+			continue
+		}
+		s.logger.Info("starting job for discovered host", slog.String("host", key))
+		stop := make(chan struct{})
+		s.running[key] = stop
+		go job.Run(stop)
+	}
+}

--- a/src/internal/discovery_manager_test.go
+++ b/src/internal/discovery_manager_test.go
@@ -1,0 +1,133 @@
+package internal
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func testMetrics() *Metrics {
+	config := &Config{
+		JobLabelName:   "job_name",
+		DurationMetric: "canary_ng_duration",
+		FailuresMetric: "canary_ng_failures",
+		JobsMetric:     "canary_ng_jobs",
+		QueriesMetric:  "canary_ng_queries",
+		QueryLabels:    QueryLabelsConfig{Name: "query"},
+	}
+	return NewMetrics(prometheus.NewRegistry(), config)
+}
+
+func newTestDiscoveryManager(discover func() ([]string, error)) *DiscoveryManager {
+	config := JobConfig{
+		Name:           "discovery",
+		Type:           JOB_TYPE_POSTGRESQL,
+		QueryType:      QUERY_TYPE_READ,
+		Database:       "canary_db",
+		Table:          "canary_table",
+		Interval:       3600,
+		Timeout:        1,
+		JobPerHost:     true,
+		HostsDiscovery: DiscoveryConfig{Type: DISCOVER_TYPE_CONSUL},
+	}
+	return &DiscoveryManager{
+		config:       config,
+		metrics:      testMetrics(),
+		queryLabels:  QueryLabelsConfig{Name: "query"},
+		jobLabelName: "job_name",
+		interval:     time.Second,
+		logger:       slog.With("job", config.Name),
+		running:      map[string]chan struct{}{},
+		discover:     discover,
+	}
+}
+
+func runningKeys(s *DiscoveryManager) []string {
+	keys := make([]string, 0, len(s.running))
+	for k := range s.running {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func isClosed(ch chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
+func TestDiscoveryManagerReconcile(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	hosts := []string{"127.0.0.1", "127.0.0.2"}
+	discoverErr := error(nil)
+	discover := func() ([]string, error) { return hosts, discoverErr }
+
+	s := newTestDiscoveryManager(discover)
+
+	t.Run("starts a job per discovered host", func(t *testing.T) {
+		s.reconcile()
+		got := runningKeys(s)
+		want := []string{"127.0.0.1", "127.0.0.2"}
+		if fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Errorf("got %v, expect %v", got, want)
+		}
+	})
+
+	t.Run("keeps surviving hosts and reconciles the delta", func(t *testing.T) {
+		survivor := s.running["127.0.0.2"]
+		vanished := s.running["127.0.0.1"]
+
+		hosts = []string{"127.0.0.2", "127.0.0.3"}
+		s.reconcile()
+
+		got := runningKeys(s)
+		want := []string{"127.0.0.2", "127.0.0.3"}
+		if fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Errorf("got %v, expect %v", got, want)
+		}
+		if s.running["127.0.0.2"] != survivor {
+			t.Error("surviving host job was restarted instead of kept")
+		}
+		if !isClosed(vanished) {
+			t.Error("vanished host job was not stopped")
+		}
+	})
+
+	t.Run("keeps running jobs when discovery fails", func(t *testing.T) {
+		before := runningKeys(s)
+
+		discoverErr = fmt.Errorf("consul unreachable")
+		s.reconcile()
+		discoverErr = nil
+
+		if got := runningKeys(s); fmt.Sprint(got) != fmt.Sprint(before) {
+			t.Errorf("got %v, expect unchanged %v", got, before)
+		}
+	})
+
+	t.Run("keeps running jobs when discovery returns no host", func(t *testing.T) {
+		before := runningKeys(s)
+
+		hosts = []string{}
+		s.reconcile()
+		hosts = []string{"127.0.0.2", "127.0.0.3"}
+
+		if got := runningKeys(s); fmt.Sprint(got) != fmt.Sprint(before) {
+			t.Errorf("got %v, expect unchanged %v", got, before)
+		}
+	})
+
+	for _, ch := range s.running {
+		close(ch)
+	}
+}

--- a/src/internal/job.go
+++ b/src/internal/job.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -15,6 +16,7 @@ import (
 
 const (
 	JOB_INTERVAL          = 1
+	DISCOVERY_INTERVAL    = 60
 	JOB_NAME_SEPARATOR    = "/"
 	JOB_TYPE_CLICKHOUSE   = "clickhouse"
 	JOB_TYPE_MONGODB      = "mongodb"
@@ -42,16 +44,31 @@ type Job struct {
 
 // Create multiple jobs
 func NewJobs(config JobConfig, metrics *Metrics, queryLabels QueryLabelsConfig, jobLabelName string) (jobs []*Job, err error) {
+	hosts, err := ResolveHosts(config)
+	if err != nil {
+		return nil, err
+	}
 
-	var hosts []string
+	jobMap, err := BuildJobs(config, hosts, metrics, queryLabels, jobLabelName)
+	if err != nil {
+		return nil, err
+	}
 
-	if config.Host != "" {
-		hosts = []string{config.Host}
+	jobs = make([]*Job, 0, len(jobMap))
+	for _, j := range jobMap {
+		jobs = append(jobs, j)
+	}
+	return jobs, nil
+}
 
-	} else if len(config.Hosts) > 0 {
-		hosts = config.Hosts
-
-	} else if config.HostsDiscovery.Type != "" {
+// Resolve the list of hosts a job targets, querying discovery when configured
+func ResolveHosts(config JobConfig) (hosts []string, err error) {
+	switch {
+	case config.Host != "":
+		return []string{config.Host}, nil
+	case len(config.Hosts) > 0:
+		return config.Hosts, nil
+	case config.HostsDiscovery.Type != "":
 		hosts, err = DiscoverHosts(config.HostsDiscovery)
 		if err != nil {
 			return nil, err
@@ -59,9 +76,17 @@ func NewJobs(config JobConfig, metrics *Metrics, queryLabels QueryLabelsConfig, 
 		if len(hosts) == 0 {
 			return nil, fmt.Errorf("0 host found by discovery")
 		}
-	} else if config.DSN == "" {
+		return hosts, nil
+	case config.DSN == "":
 		return nil, fmt.Errorf("host, hosts, hosts_discovery or dsn required for job %s", config.Name)
 	}
+	return nil, nil
+}
+
+// Build the jobs targeting the given hosts, keyed by a stable identity so a
+// discovery manager can reconcile a running set against a freshly discovered one
+func BuildJobs(config JobConfig, hosts []string, metrics *Metrics, queryLabels QueryLabelsConfig, jobLabelName string) (map[string]*Job, error) {
+	jobs := map[string]*Job{}
 
 	if config.JobPerHost && len(hosts) > 0 {
 		for _, h := range hosts {
@@ -73,7 +98,7 @@ func NewJobs(config JobConfig, metrics *Metrics, queryLabels QueryLabelsConfig, 
 			if err != nil {
 				return nil, err
 			}
-			jobs = append(jobs, j)
+			jobs[h] = j
 			// Restore original name
 			config.Name = name
 		}
@@ -82,13 +107,19 @@ func NewJobs(config JobConfig, metrics *Metrics, queryLabels QueryLabelsConfig, 
 
 	config.Hosts = hosts
 	config.Name = AddHostPrefix(config)
-
 	j, err := NewJob(config, metrics, queryLabels, jobLabelName)
 	if err != nil {
 		return nil, err
 	}
+	jobs[hostsKey(hosts)] = j
+	return jobs, nil
+}
 
-	return []*Job{j}, nil
+// Stable key for a set of hosts, independent of discovery ordering
+func hostsKey(hosts []string) string {
+	sorted := append([]string{}, hosts...)
+	sort.Strings(sorted)
+	return strings.Join(sorted, ",")
 }
 
 // Add host prefix to the job name
@@ -406,17 +437,24 @@ func (j *Job) EndMeasurement(queryType string) {
 	j.IncrQueries()
 }
 
-func (j *Job) Run() {
+// Run measures on the job interval until stop is closed. A nil stop channel
+// runs for the lifetime of the process.
+func (j *Job) Run(stop <-chan struct{}) {
 	j.logger.Info("job started")
-	for {
-		j.Measure()
-		j.logger.Info("measurement performed")
+	j.Measure()
+	j.logger.Info("measurement performed")
 
-		w := "second"
-		if j.config.Interval > 1 {
-			w = "seconds"
+	ticker := time.NewTicker(time.Duration(j.config.Interval) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-stop:
+			j.logger.Info("job stopped")
+			return
+		case <-ticker.C:
+			j.Measure()
+			j.logger.Info("measurement performed")
 		}
-		j.logger.Debug(fmt.Sprintf("waiting for %d %s before next measurement", j.config.Interval, w))
-		time.Sleep(time.Duration(j.config.Interval * int(time.Second)))
 	}
 }


### PR DESCRIPTION
Re-run host discovery on an interval so hosts appearing or disappearing are picked up without restarting the application.

A Supervisor reconciles the running jobs against the freshly discovered hosts: new hosts get a job, vanished hosts have theirs stopped. On a discovery failure or an empty result the running jobs are kept so a transient outage does not interrupt monitoring. The interval is configurable via the discovery `interval` setting (defaults to 60s).

Job.Run now takes a stop channel and uses a ticker instead of sleeping, letting the supervisor stop individual jobs. NewJobs is split into ResolveHosts and BuildJobs, the latter keying jobs by a stable host identity so the running set can be reconciled.

Fixes #19.